### PR TITLE
replace 'search to type' with search button

### DIFF
--- a/Umbraco/App_Plugins/DiploAuditLogViewer/backoffice/diploAuditTrail/edit.html
+++ b/Umbraco/App_Plugins/DiploAuditLogViewer/backoffice/diploAuditTrail/edit.html
@@ -14,7 +14,7 @@
 
             <div class="umb-sub-header">
 
-                <form class="form-inline">
+                <form class="form-inline" ng-submit="vm.search()">
 
                     <div class="input-prepend">
                         <span class="add-on"><i class="icon-activity"></i></span>
@@ -39,9 +39,18 @@
 
                     <div class="input-prepend">
                         <span class="add-on"><i class="icon-search"></i></span>
-                        <input type="search" class="form-control input-medium" placeholder="Type to search..." ng-model="vm.criteria.searchTerm" ng-change="vm.search(vm.criteria.searchTerm)">
+                        <input type="search" class="form-control input-medium" placeholder="Search..." ng-model="vm.criteria.searchTerm">
                         <span class="add-on diplo-button delete" ng-show="vm.criteria.searchTerm" ng-click="vm.criteria.searchTerm = null; vm.logTypeChange()"><i class="icon-delete"></i></span>
                     </div>
+
+                    <umb-button
+                        action="vm.search()"
+                        type="button"
+                        button-style="success"
+                        state="vm.buttonState"
+                        label="Search"
+                        disabled="vm.buttonState !== 'init'">
+                    </umb-button>
 
                     <div class="pull-right">
                         <div class="input-prepend">


### PR DESCRIPTION
Hi Dan Diplo,

During development we faced a lot of issue with "Search to type" functionality. There wasn't any debounce or a minimum searchterm length which causes a lot of network requests to happen.
Those many request resulted in Sql Timeout Exceptions.

Instead of "Search to type", we recommend to enable "enter" and use an Umbraco button (stateful).
While the request is pending the form will not allow for further requests.

Best regards,
Vigan